### PR TITLE
Resolving issue where assets never served for production builds

### DIFF
--- a/src/helpers/ManifestHelper.php
+++ b/src/helpers/ManifestHelper.php
@@ -146,7 +146,7 @@ class ManifestHelper
                 continue;
             }
             // If the $path isn't in the $manifestKey, skip it
-            if (strpos($path, $manifestKey) === false) {
+            if (strpos($manifestKey, $path) === false) {
                 continue;
             }
             // Include the entry script


### PR DESCRIPTION
### Description

HUnless I have misunderstood the setup process and some of my settings are incorrect, I believe the `strpos` values need to be reversed. Hard to believe that nobody has hit this yet, so I suspect I am the problem, if so sorry for the noise...

When debugging here, my `$path` never gets beyond this `continue`.

![image](https://user-images.githubusercontent.com/2337910/146055745-74b62e5b-5ca6-4f76-afe6-81ddca4f71ca.png)


```php
strpos(string $haystack, string $needle)
```

before:

```php
if (strpos($path, $manifestKey) === false) {
```

after:

```php
if (strpos($manifestKey, $path) === false) {
```

This change does appear to serve the correct assets, though comes with a likely unrelated issue:

```
Uncaught SyntaxError: 15
    at Jo (vendor.d63320e8.js:1)
```