### PR TITLE
Use `App::env()` to determine value of $useDevServer

### DIFF
--- a/src/services/VitePluginService.php
+++ b/src/services/VitePluginService.php
@@ -11,6 +11,7 @@
 namespace nystudio107\pluginvite\services;
 
 use Craft;
+use craft\helpers\App;
 use nystudio107\pluginvite\helpers\FileHelper;
 
 /**
@@ -51,7 +52,7 @@ class VitePluginService extends ViteService
             return;
         }
         // See if the $pluginDevServerEnvVar env var exists, and if not, don't run off of the dev server
-        $useDevServer = getenv($this->pluginDevServerEnvVar);
+        $useDevServer = (bool) App::env($this->pluginDevServerEnvVar);
         if ($useDevServer === false) {
             $this->useDevServer = false;
         }


### PR DESCRIPTION
### Description

In our projects we use https://github.com/symfony/dotenv to manage our env vars.

> Symfony Dotenv parses .env files to make environment variables stored in them accessible via $_SERVER or $_ENV.

By default symfony/dotenv does not use putenv: https://github.com/symfony/dotenv/blob/6.1/Dotenv.php#L59-L70

App::env() is a little more forgiving. It checks:

* `$_SERVER[$name]`
* `getenv($name)`
* `defined($name)`