### PR TITLE
Fix errors on Windows with paths to manifest

### DIFF
--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -59,7 +59,7 @@ class FileHelper
             ],
         ]);
         // If this is a file path such as for the `manifest.json`, add a FileDependency so it's cache bust if the file changes
-        if (!UrlHelper::isAbsoluteUrl($pathOrUrl)) {
+        if (!self::isAbsoluteUrl($pathOrUrl)) {
             $dependency = new ChainedDependency([
                 'dependencies' => [
                     new FileDependency([
@@ -79,7 +79,7 @@ class FileHelper
             self::CACHE_KEY . $cacheKeySuffix . $pathOrUrl,
             function() use ($pathOrUrl, $callback) {
                 $contents = null;
-                if (UrlHelper::isAbsoluteUrl($pathOrUrl)) {
+                if (self::isAbsoluteUrl($pathOrUrl)) {
                     $response = self::fetchResponse($pathOrUrl);
                     if ($response && $response->getStatusCode() === 200) {
                         $contents = $response->getBody()->getContents();
@@ -153,5 +153,20 @@ class FileHelper
         $path = self::createUrl(self::SCRIPTS_DIR, $name);
 
         return self::fetch($path, null, $cacheKeySuffix) ?? '';
+    }
+
+    /**
+     * Returns whether the path or URL is an absolute URL
+     *
+     * @param string $pathOrUrl
+     * @return bool
+     */
+    public static function isAbsoluteUrl(string $pathOrUrl): bool
+    {
+        if (str_contains($pathOrUrl, '//')) {
+            return UrlHelper::isAbsoluteUrl($pathOrUrl);
+        }
+
+        return false;
     }
 }

--- a/src/services/VitePluginService.php
+++ b/src/services/VitePluginService.php
@@ -12,6 +12,7 @@ namespace nystudio107\pluginvite\services;
 
 use Craft;
 use craft\helpers\App;
+use craft\helpers\FileHelper as CraftFileHelper;
 use nystudio107\pluginvite\helpers\FileHelper;
 
 /**
@@ -68,7 +69,7 @@ class VitePluginService extends ViteService
             $bundle->sourcePath,
             true
         );
-        $this->manifestPath = FileHelper::createUrl($bundle->sourcePath, self::MANIFEST_FILE_NAME);
+        $this->manifestPath = CraftFileHelper::normalizePath($bundle->sourcePath . '/' . self::MANIFEST_FILE_NAME);
         if ($baseAssetsUrl !== false) {
             $this->serverPublic = $baseAssetsUrl;
         }


### PR DESCRIPTION
I'm having issues with [Formie](https://github.com/verbb/formie/issues/1882) (on Craft 5) where the paths are resolving incorrectly for many things, but mainly the `manifest.json`.

There are two parts to this PR:

**Fix path to manifest**
You may have to explain to me why you use [`FileHelper::createUrl()`](https://github.com/nystudio107/craft-plugin-vite/blob/5a954da2b1ea19cebe4462f4248b453a486408a9/src/services/VitePluginService.php#L71) to get the **path** for the manifest file. It's a path, not a URL?

```
Windows:
C:\Users\joshcrawford\public_html\formie-craft5\vendor/verbb/formie/src/web/assets/forms/dist/manifest.json

MacOS
/Users/joshcrawford/public_html/craft50-alpha/vendor/verbb/formie/src/web/assets/forms/dist/manifest.json
```

You'll notice in Windows that the slashes are incorrect for a path, but correct if we assumed a URL, or if we assumed Linux/MacOS.

There might be other instances of `FileHelper::createUrl()` being used when dealing with paths.

**Fix `isAbsoluteUrl` check**
When it comes to fetching the manifest, you fetch it with `curl`. With the path sorted, that should be working fine, but an interesting result happens for some [`UrlHelper::isAbsoluteUrl($pathOrUrl)`](https://github.com/nystudio107/craft-plugin-vite/blob/5a954da2b1ea19cebe4462f4248b453a486408a9/src/helpers/FileHelper.php#L62) checks in your `FileHelper`.

```
UrlHelper::isAbsoluteUrl('/Users/joshcrawford/public_html/craft50-alpha/vendor/verbb/formie/src/web/assets/forms/dist/manifest.json');
false

UrlHelper::isAbsoluteUrl('C:\Users\joshcrawford\public_html\formie-craft5\vendor\verbb\formie\src\web\assets\forms\dist\manifest.json');
true
```

Here, you can see we input the MacOS path and the WIndows path respectively into this function, expecting the same result - but it's not! It's treating the `C:\Users\...` as an absolute URL, which it certainly isn't. I'm surprised that Craft/Yii don't check if the string you pass into it is a URL first, but that's probably unique to your use-case here, where you allow either a path or URL.