### PR TITLE
fix: replace strpos with strrpos since file names could be kebap case

### DIFF
--- a/src/helpers/ManifestHelper.php
+++ b/src/helpers/ManifestHelper.php
@@ -320,14 +320,15 @@ class ManifestHelper
         $pathInfo = pathinfo($path);
         $filename = $pathInfo['filename'];
         $extension = $pathInfo['extension'];
-        $hashPos = strpos($filename, '.') ?: strlen($filename);
+        $hashPos = strrpos($filename, '.') ?: strlen($filename);
         $hash = substr($filename, $hashPos);
         // Vite 5 now uses a `-` to separate the version hash, so account for that as well
         if (empty($hash) && str_contains($filename, '-')) {
-            $hash = substr($filename, strpos($filename, '-'));
+            $hash = substr($filename, strrpos($filename, '-'));
         }
         $filename = str_replace($hash, '', $filename);
 
         return implode('.', [$filename, $extension]);
     }
 }
+


### PR DESCRIPTION
### Description
It seems to have been forgotten that vite uses base64 naming for the bundle prefix by default, which includes special characters such as `-` : https://rollupjs.org/configuration-options/#output-hashcharacters

This could lead to issues and should be addressed in the plugin's documentation, since otherwise the function does not extract the hash as intended. 

In addition to that `strpos` might not be a proper function for determining the hash itself since the initial filename could be written in kebap case and `strpos` returns the first occurrence of a given character. Therefore my suggestion would be to take `strrpos` instead, as well as for determining the initial `hashPos`.

All in all it might even be better to give the developer the opportunity to define a custom hash prefix by for example an environment variable, since vite also allows custom naming of the output files using rollup. https://rollupjs.org/configuration-options/

Kind regards

### Related issues
