### PR TITLE
fix: Early-return from VitePluginService::init() for console requests (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Plugin Vite Changelog
 
+## Unreleased
+### Fixed
+* Early-return from `VitePluginService::init()` for console requests ([#31](https://github.com/nystudio107/craft-plugin-vite/issues/31))
+
 ## 5.0.2 - 2024.08.13
 ### Added
 * Add a `craft.vite.integrity()` method that will extract the integrity hash (for building a Content Security Policy)

--- a/src/services/VitePluginService.php
+++ b/src/services/VitePluginService.php
@@ -76,13 +76,15 @@ class VitePluginService extends ViteService
         if (!$this->assetClass || $this->devServerRunning()) {
             return;
         }
+        $request = Craft::$app->getRequest();
+        // https://github.com/nystudio107/craft-plugin-vite/issues/31
+        if ($request->getIsConsoleRequest()) {
+            return;
+        }
         // The Vite service is generally only needed for CP requests & previews, save a db write, see:
         // https://github.com/nystudio107/craft-plugin-vite/issues/27
-        $request = Craft::$app->getRequest();
-        if (!$this->useForAllRequests && !$request->getIsConsoleRequest()) {
-            if (!$request->getIsCpRequest() && !$request->getIsPreview() && !in_array($request->getSegment(1), $this->firstSegmentRequests, true)) {
-                return;
-            }
+        if (!$this->useForAllRequests && !$request->getIsCpRequest() && !$request->getIsPreview() && !in_array($request->getSegment(1), $this->firstSegmentRequests, true)) {
+            return;
         }
         // Map the $manifestPath and $serverPublic to the hashed `/cpresources/` path & URL for our AssetBundle
         $bundle = new $this->assetClass();


### PR DESCRIPTION
## Summary

Fix #31 by an early-return from `VitePluginService::init()` for console requests.

Without this, on Craft 5.9.21 and above: SEOmatic's Install migration throws `The directory does not exist:` when the bundle's `sourcePath` alias hasn't been registered yet.

## Behavior change

Previously the inner CP/preview guard short-circuited on `getIsConsoleRequest()`, but execution then fell through to the `getPublishedUrl()` call regardless. After this change, all console requests bail out before that call, matching the behavior of the prior guard.

`useForAllRequests = true` paths are unaffected for web requests; console requests under that flag also now bail (they were previously broken on 5.9.21).